### PR TITLE
chore: Bump vault utils to fix supported vault version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "aegis-vault-utils"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880e42d68914d6abbdcc3a0d29e81531197945173db8c5013552d4638d0ea618"
+checksum = "24ab421a036fb4a2c8331bf700d2779ff4851718ce7eb85fd931399765a1891a"
 dependencies = [
  "aes-gcm",
  "base64 0.22.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-aegis-vault-utils = "0.4"
+aegis-vault-utils = "0.5.0"
 arboard = "3.2"
 clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 color-eyre = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> Result<()> {
             exit(1);
         }
     };
-    let entries = match parse_vault(&file_contents, args.password_input) {
+    let entries = match parse_vault(&file_contents, &args.password_input) {
         Ok(db) => db
             .entries
             .into_iter()


### PR DESCRIPTION
We now support up to database version 3.

See https://github.com/Granddave/aegis-vault-utils/commit/71c5d8467c77fcd9a2e7a4e9492aeb23c41bd4c3

Fixes #9 