### PR TITLE
feat: Display the OTP in groups of 3 digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Aegis-rs allows you to read the OTP directly in the terminal or paste it using t
 
 ```sh
 · Twitter (@johndoe)
-121921 (28s left)
+121 921 (28s left)
 ```
 
 
@@ -80,13 +80,13 @@ To unlock the Aegis vault Aegis-rs supports the following methods:
 - `--issuer <ISSUER>`: Filter entries by entry issuer.
 - `--name <NAME>`: Filter entries by entry name.
 - `--json`: Output the calculated OTPs as JSON.
-
+- `--digit-group-size <SIZE>`: Display the selected OTP in group of SIZE digit
 
 ## TODO
 
 - [x] Add password file feature
 - [x] Add countdown timer and refresh TOTP code after timeout
-- [ ] Display digits in groups
+- [x] Display digits in groups
 - [x] Add TOTP to clipboard
 - [x] Add CI
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,13 @@ struct Cli {
     entry_filter: EntryFilter,
     #[clap(long, help = "Print to stdout in JSON")]
     json: bool,
+    #[clap(
+        long,
+        help = "Group OTP digits",
+        env = "AEGIS_DIGIT_GROUP_SIZE",
+        default_value_t = 3
+    )]
+    digit_group_size: usize,
 }
 
 #[derive(Args)]
@@ -103,7 +110,7 @@ fn set_sigint_hook() {
     .expect("Setting SIGINT handler");
 }
 
-fn print_otp_every_second(entry_info: &EntryInfo) -> Result<()> {
+fn print_otp_every_second(entry_info: &EntryInfo, otp_group_size: usize) -> Result<()> {
     let term = Term::stdout();
     term.hide_cursor()?;
 
@@ -149,9 +156,11 @@ fn print_otp_every_second(entry_info: &EntryInfo) -> Result<()> {
             6..=15 => Style::new().yellow(),
             _ => Style::new().green(),
         };
-        let line = style
-            .bold()
-            .apply_to(format!("{} ({}s left)", otp_code, remaining_time));
+        let line = style.bold().apply_to(format!(
+            "{} ({}s left)",
+            group_otp_digits(&otp_code, otp_group_size),
+            remaining_time
+        ));
         term.write_line(line.to_string().as_str())?;
         std::thread::sleep(Duration::from_millis(60));
         term.clear_last_lines(1)?;
@@ -159,6 +168,17 @@ fn print_otp_every_second(entry_info: &EntryInfo) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn group_otp_digits(otp: &str, otp_group_size: usize) -> String {
+    let mut result = String::with_capacity(otp.len() + otp.len() / otp_group_size);
+    for (i, c) in otp.chars().enumerate() {
+        if i > 0 && i % otp_group_size == 0 {
+            result.push(' ');
+        }
+        result.push(c);
+    }
+    result
 }
 
 fn entries_to_json(entries: &[Entry]) -> Result<()> {
@@ -181,7 +201,7 @@ fn entries_to_json(entries: &[Entry]) -> Result<()> {
     Ok(())
 }
 
-fn fuzzy_select(entries: &[Entry]) -> Result<()> {
+fn fuzzy_select(entries: &[Entry], otp_group_size: usize) -> Result<()> {
     let items: Vec<String> = entries
         .iter()
         .map(|entry| format!("{} ({})", entry.issuer.trim(), entry.name.trim()))
@@ -203,7 +223,7 @@ fn fuzzy_select(entries: &[Entry]) -> Result<()> {
         match selection {
             Some(index) => {
                 let entry_info = &entries.get(index).unwrap().info;
-                print_otp_every_second(entry_info)?;
+                print_otp_every_second(entry_info, otp_group_size)?;
             }
             None => {
                 // Exit on Escape key
@@ -247,7 +267,7 @@ fn main() -> Result<()> {
     if args.json {
         entries_to_json(&entries)?;
     } else {
-        fuzzy_select(&entries)?;
+        fuzzy_select(&entries, args.digit_group_size)?;
     }
 
     Ok(())


### PR DESCRIPTION
As a daily user of aegis-rs, I wanted to contribute to your project.

I implemented a function to group the digits of the displayed OTP. It doesn't change the value copied in the clipboard.

The function may handle any size of OTP.
To mimic aegis display I set the group size to 3. Maybe it would be better to use an env variable.

I also updated the README to reflect the changes I made.

I'm very new to rust programming so my code may not be very good or idiomatic. If you think should modify something, your feedback is welcome.

Thank you for the work you put into aegis-rs !