### PR TITLE
fix: Try to improve Ctrl+C and Esc key behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "console",
  "ctrlc",
  "dialoguer",
+ "libc",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ ctrlc = "3.5"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ use aegis_vault_utils::{
     vault::{parse_vault, PasswordGetter},
 };
 
+mod terminal_state;
+use terminal_state::TerminalState;
+
 #[derive(Parser)]
 #[clap(
     name = "aegis-rs",
@@ -100,14 +103,6 @@ impl PasswordGetter for PasswordInput {
                 .map_err(|e| eyre!("Failed to get password: {}", e)),
         }
     }
-}
-
-fn set_sigint_hook() {
-    ctrlc::set_handler(move || {
-        Term::stdout().show_cursor().expect("Showing cursor");
-        exit(0);
-    })
-    .expect("Setting SIGINT handler");
 }
 
 fn print_otp_every_second(entry_info: &EntryInfo, otp_group_size: usize) -> Result<()> {
@@ -205,11 +200,22 @@ fn entries_to_json(entries: &[Entry]) -> Result<()> {
 }
 
 fn fuzzy_select(entries: &[Entry], otp_group_size: usize) -> Result<()> {
+    // Snapshot terminal flags before anything modifies them, and register
+    // a SIGTERM/SIGINT handler that restores them before exiting.
+    let saved_state = TerminalState::save()?;
+    ctrlc::set_handler(move || {
+        let _ = saved_state.restore();
+        let term = Term::stdout();
+        let _ = term.clear_line();
+        let _ = term.write_str("\r");
+        let _ = term.show_cursor();
+        exit(0);
+    })?;
+
     let items: Vec<String> = entries
         .iter()
         .map(|entry| format!("{} ({})", entry.issuer.trim(), entry.name.trim()))
         .collect();
-    set_sigint_hook();
     loop {
         let selection = match FuzzySelect::with_theme(&ColorfulTheme::default())
             .items(&items)
@@ -220,6 +226,7 @@ fn fuzzy_select(entries: &[Entry], otp_group_size: usize) -> Result<()> {
             Ok(selection) => selection,
             Err(_) => {
                 // Exit on e.g. Ctrl+C
+                let _ = Term::stdout().show_cursor();
                 exit(0);
             }
         };

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -1,0 +1,69 @@
+use std::io;
+
+/// A snapshot of the terminal's input flags that can be restored later.
+///
+/// On Unix this captures the full `termios` struct (via `tcgetattr`).
+/// On Windows we stub this out since the initial issue was on Linux.
+#[derive(Clone, Copy)]
+pub struct TerminalState {
+    inner: PlatformState,
+}
+
+impl TerminalState {
+    /// Snapshot the current terminal input flags.
+    pub fn save() -> io::Result<Self> {
+        Ok(Self {
+            inner: PlatformState::save()?,
+        })
+    }
+
+    /// Restore the previously saved terminal input flags.
+    pub fn restore(&self) -> io::Result<()> {
+        self.inner.restore()
+    }
+}
+
+// Unix (Linux, macOS, etc.)
+
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+struct PlatformState {
+    termios: libc::termios,
+}
+
+#[cfg(unix)]
+impl PlatformState {
+    fn save() -> io::Result<Self> {
+        let mut termios = unsafe { std::mem::zeroed() };
+        let ret = unsafe { libc::tcgetattr(libc::STDIN_FILENO, &mut termios) };
+        if ret != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { termios })
+    }
+
+    fn restore(&self) -> io::Result<()> {
+        let ret = unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &self.termios) };
+        if ret != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+// Windows (stub)
+
+#[cfg(not(unix))]
+#[derive(Clone, Copy)]
+struct PlatformState;
+
+#[cfg(not(unix))]
+impl PlatformState {
+    fn save() -> io::Result<Self> {
+        Ok(Self)
+    }
+
+    fn restore(&self) -> io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Here we have removed ctrlc crate, thread and the channel and instead use raw mode and set attributes and poll.

Fixes #28 